### PR TITLE
Problem:  (fix #121) No instruction to verify the node is running/syncing

### DIFF
--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -15,17 +15,17 @@ We officially support macOS, Windows and Linux only. Other platforms may work bu
 
 ### Prepare your machine
 
-To run Crypto.org Chain nodes in the testnet, you will need a machine with the following minimum requirements:
+- To run Crypto.org Chain nodes in the testnet, you will need a machine with the following minimum requirements:
 
-- Dual-core, x86_64 architecture processor;
-- 4 GB RAM;
-- 100 GB of storage space.
+  - Dual-core, x86_64 architecture processor;
+  - 4 GB RAM;
+  - 100 GB of storage space.
 
-For Crypto.org Chain mainnet in the future, you will need a machine with the following minimum requirements:
+- For Crypto.org Chain mainnet in the future, you will need a machine with the following minimum requirements:
 
-- 4-core, x86_64 architecture processor;
-- 16 GB RAM;
-- 1 TB of storage space.
+  - 4-core, x86_64 architecture processor;
+  - 16 GB RAM;
+  - 1 TB of storage space.
 
 ## Step 1. Get the Crypto.org Chain binary
 
@@ -226,11 +226,23 @@ WantedBy=multi-user.target
 
 It should begin fetching blocks from the other peers. Please wait until it is fully synced before moving onto the next step.
 
-For example, one can check the current block height by querying the public full node by:
+- You can query the node syncing status by
+  ```bash
+  $ ./chain-maind status 2>&1 | jq '.SyncInfo.catching_up'
+  ```
+  If the above command returns `false`, It means that your node **is fully synced**; otherwise, it returns `true` and implies your node is still catching up.
 
-```bash
-curl -s https://testnet-croeseid.crypto.org:26657/commit | jq "{height: .result.signed_header.header.height}"
-```
+- One can check the current block height by querying the public full node by:
+
+  ```bash
+  curl -s https://testnet-croeseid.crypto.org:26657/commit | jq "{height: .result.signed_header.header.height}"
+  ```
+
+  and you can check your node's progress (in terms of block height) by
+
+  ```bash 
+  $ ./chain-maind status 2>&1 | jq '.SyncInfo.latest_block_height'
+  ```
 
 ### Step 3-5. Send a `create-validator` transaction
 
@@ -307,7 +319,7 @@ You can check your _transferable_ balance with the `balances` command under the 
 :::details Example: Check your address balance
 
 ```bash
-$ chain-maind query bank balances tcro1quw5r22pxy8znjtdkgqc65atrm3x5hg6vycm5n
+$ ./chain-maind query bank balances tcro1quw5r22pxy8znjtdkgqc65atrm3x5hg6vycm5n
 
 balances:
 - amount: "10005471622381693"
@@ -329,8 +341,7 @@ Transfer operation involves the transfer of tokens between two addresses.
 :::details Example: Send 10tcro from an address to another.
 
 ```bash
-$ chain-maind tx bank send Default
-tcro1j7pej8kplem4wt50p4hfvndhuw5jprxxn5625q 10tcro --chain-id "testnet-croeseid-2"
+$ ./chain-maind tx bank send Default tcro1j7pej8kplem4wt50p4hfvndhuw5jprxxn5625q 10tcro --chain-id "testnet-croeseid-2"
   ## Transaction payload##
   {"body":{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_address"....}
 confirm transaction before signing and broadcasting [y/N]: y
@@ -364,7 +375,7 @@ On the other hand, we can create a `Unbond` transaction to unbond the delegated 
 ::: details Example: Unbond funds from a validator under the address `tcrocncl16k...edcer`
 
 ```bash
-$ chain-maind tx staking unbond tcrocncl16kqr009ptgken6qsxnzfnyjfsq6q97g3uedcer 100tcro --from Default --chain-id "testnet-croeseid-2"
+$ ./chain-maind tx staking unbond tcrocncl16kqr009ptgken6qsxnzfnyjfsq6q97g3uedcer 100tcro --from Default --chain-id "testnet-croeseid-2"
 ## Transaction payload##
 {"body":{"messages":[{"@type":"/cosmos.staking.v1beta1.MsgUndelegate"...}
 confirm transaction before signing and broadcasting [y/N]: y

--- a/docs/wallets/mainnet-address-generation.md
+++ b/docs/wallets/mainnet-address-generation.md
@@ -11,13 +11,13 @@ Account address for mainnet starts with prefix `cro`. For example: `cro1y8ua5lac
 Crypto.org Chain has [registered](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) coin type `394` as defined in [BIP44 standard](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
 
 Coin Type: 394 <br />
-Derivation Path: `44'/394'/0'/0/{index}`  where index starts from 0.
+Derivation Path: `44'/394'/0'/0/{index}` where index starts from 0.
 
 i.e. the first address is derived at path `44'/394'/0'/0/0` and the second one at path `44'/394'/0'/0/1`.
 
 ## How to generate address
 
-::: warning: MAKE SURE YOU BACKUP YOUR MNEMONIC WORDS
+::: warning MAKE SURE YOU BACKUP YOUR MNEMONIC WORDS
 Before you use the generated mainnet addresses to receive funds on mainnet, make sure that you have backup your address's mnemonic words correctly in a safe place and the mnemonic words are correct such that it can restore to your wallet address in the future.
 
 You are the sole owner of your wallet mnemonic words and there is no way for Crypto.org to restore your wallet or recover your funds if you lost the mnemonic words.
@@ -27,16 +27,18 @@ You are the sole owner of your wallet mnemonic words and there is no way for Cry
 We recommend you to generate an address only on a trusted and secure computer. To further enhance the security, you should consider to run on a air-gapped (offline) machine.
 :::
 
-::: warning: ALWAYS VERIFY YOUR MNEMONIC WORDS AND ADDRESS
+::: warning ALWAYS VERIFY YOUR MNEMONIC WORDS AND ADDRESS
 To make sure you have backed up the mnemonic words correctly, we recommend you to try to restore your wallet with the mnemonic words and verify the address derived is the same.
 
 For more details on how to verify your mnemonic words and addresses, please check [Mainnet Address Verification](./mainnet-address-verification.md)
 :::
-There are four ways to generate the mainnet address by using: 
+There are four ways to generate the mainnet address by using:
+
 - [Release Binary (CLI)](#a-release-binary-cli);
 - [Ledger Wallet](#b-ledger-wallet);
 - [Programmatically via Crypto.org Chain JavaScript Library](#c-programmatically); and
 - [Crypto.org Chain Desktop Wallet (Beta version)](#d-crypto-org-chain-desktop-wallet-beta).
+
 ## A. Release Binary (CLI)
 
 Supported OS: Linux, Mac OS and Windows
@@ -52,20 +54,23 @@ $ tar -zxvf chain-main_1.0.0_Linux_x86_64.tar.gz
 
 If you are downloading the binary for other operating systems, make sure you are downloading `v1.0.0`, which is the version targeting for mainnet.
 
-Before moving to the next step, kindly check your `chain-maind` version by 
+Before moving to the next step, kindly check your `chain-maind` version by
 
 ```bash
 $ ./chain-maind version
 1.0.0
+```
+
 #### Step 2. Create a new key and address
 
 Run the following command to create a new address. For example, you can create a key with the name "Default" by:
 
 ```bash
-$ ./chain-maind keys add Default 
+$ ./chain-maind keys add Default
 ```
 
 You can find the generated address after running the command. **Please make sure that you have safely backed up the mnemonic words that appear on the last line.**
+
 ```bash
 - name: Default
   type: local
@@ -87,7 +92,7 @@ scare blur bless unfair chat gadget leaf reveal job depend daughter unveil fatal
 - Supported OS: Linux, Mac OS and Windows
 - Pre-requisite: Ledger Hardware Wallet
 
-::: tip: Crypto.org Chain Ledger Application Is In Development Mode
+::: tip Crypto.org Chain Ledger Application Is In Development Mode
 The Crypto.org Chain Ledger Application is available on Ledger Live under development mode only. It is under review by the Ledger team.
 :::
 
@@ -105,9 +110,9 @@ The Crypto.org Chain Ledger Application is available on Ledger Live under develo
 
 #### Step 1-4. Search for "Crypto.com Chain" and install the application to your Ledger.
 
-<img src="./assets/mainnet-address-generation/ledger-live-cryptocom-app.png" /> 
+<img src="./assets/mainnet-address-generation/ledger-live-cryptocom-app.png" />
 
------
+---
 
 ## B-i. Ledger Wallet via Release Binary (CLI)
 
@@ -123,6 +128,7 @@ $ tar -zxvf chain-main_1.0.0_Linux_x86_64.tar.gz
 If you are downloading the binary for other operating systems, make sure you are downloading `v1.0.0`, which is the version targeting for mainnet.
 
 #### Step 2. Open the Crypto.com Chain application on your Ledger device
+
 #### Step 3. Create a new key and address
 
 Run the following command to create a new address. For example, you can create a key with the name "Default" by:
@@ -133,7 +139,7 @@ $ ./chain-maind keys add Ledger --ledger
 
 You will be prompted with the address on your Ledger device screen. Read it carefully and write it down. Afterward, confirm the address on your Ledger device.
 
-::: tip: Cannot Connect To Your Ledger Device?
+::: tip Cannot Connect To Your Ledger Device?
 If you encounter connection error when creating a wallet, you can try to unplug and plug your Ledger device to your computer again. Please make sure your Ledger device is unlocked and you have opened the "Crypto.com Chain" application on your Ledger.
 :::
 
@@ -149,14 +155,15 @@ If you encounter connection error when creating a wallet, you can try to unplug 
   pubkeys: []
 ```
 
------
+---
 
 ## B-ii. Ledger Wallet via Crypto.org Chain Desktop Wallet
 
-::: warning: DESKTOP WALLET IS IN BETA
+::: warning DESKTOP WALLET IS IN BETA
 Desktop wallet is in beta testing. Please be aware of the [potential risks](https://github.com/crypto-com/chain-desktop-wallet#warning) of using it in mainnet. You should run it only on a trusted, safe and offline computer and always verify the mnemonic words before using the address.
 :::
 Download the latest version of the Crypto.org Chain Desktop Wallet [here](https://github.com/crypto-com/chain-desktop-wallet/releases) and follow the steps below to create an address:
+
 #### Step 1. Open the application and click "Get Started" to set up an application password.
 
 <img src="./assets/mainnet-address-generation/desktop-get-started.png" />
@@ -182,10 +189,10 @@ If you encounter connection error when creating a wallet, you can try to unplug 
 
 <img src="./assets/mainnet-address-generation/ledger-desktop-address.png" />
 
-
 ## C. Programmatically
 
 You can generate the Mnemonic and address programmatically. Here is an example code snippet written in JavaScript using the [Crypto.org Chain JavaScript Library](https://github.com/crypto-com/chain-jslib) to generate the mnemonic and the mainnet address:
+
 ```javascript
 // Import the library
 const sdk = require("@crypto-com/chain-jslib");
@@ -217,7 +224,7 @@ console.log(address);
 
 Supported OS: Ubuntu, Mac OS and Windows
 
-::: warning: DESKTOP WALLET IS IN BETA
+::: warning DESKTOP WALLET IS IN BETA
 Desktop wallet is in beta testing. Please be aware of the [potential risks](https://github.com/crypto-com/chain-desktop-wallet#warning) of using it in mainnet. You should run it only on a trusted, safe and offline computer and always verify the mnemonic words before using the address.
 :::
 


### PR DESCRIPTION
Fix #121 
- `croeseid-testnet.md`: 
Added instruction to verify the node is running/syncing by `chain-maind status`.
-  `mainnet-address-generation.md`:
Fixed "warning" and "tip" VuePress admonitions.