### PR TITLE
Problem: (Fix #153) No guide for v1.2.1 upgrade

### DIFF
--- a/docs/getting-started/aws-1click.md
+++ b/docs/getting-started/aws-1click.md
@@ -215,12 +215,13 @@ If you haven't installed `chain-maind` yet, please follow [Step 1. Get the Crypt
 Mainnet
 ```bash
 $ chain-maind version
-1.1.0
+1.2.1
 ```
 - Mainnet binary for
-  [Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v1.1.0/chain-main_1.1.0_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v1.1.0/chain-main_1.1.0_Windows_x86_64.zip) are also available. 
+  [Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Windows_x86_64.zip) are also available. 
 
 Or
+
 Testnet
 ```bash
 $ chain-maind version

--- a/docs/getting-started/azure-1click.md
+++ b/docs/getting-started/azure-1click.md
@@ -214,10 +214,10 @@ If you haven't installed `chain-maind` yet, please follow [Step 1. Get the Crypt
 Mainnet
 ```bash
 $ chain-maind version
-1.1.0
+1.2.1
 ```
 - Mainnet binary for
-  [Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v1.1.0/chain-main_1.1.0_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v1.1.0/chain-main_1.1.0_Windows_x86_64.zip) are also available. 
+  [Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Windows_x86_64.zip) are also available. 
 
 Or
 Testnet

--- a/docs/getting-started/mainnet.md
+++ b/docs/getting-started/mainnet.md
@@ -5,6 +5,8 @@ This is a detailed documentation for setting up a **Validator** or a **Full Node
 
 ## Pre-requisites
 
+**Remarks**:
+Please follow this [guide](./upgrade_guide.md). If you are upgrade from `v1.1.0`/`v1.2.0` to `v1.2.1`
 
 ### Supported OS
 
@@ -26,7 +28,7 @@ We officially support macOS, Windows and Linux only. Other platforms may work, b
 The following is the minimal setup to join Crypto.org Chain Mainnet. Furthermore, you may want to run full nodes as sentries (see [Tendermint](https://docs.tendermint.com/master/tendermint-core/running-in-production.html)),  restrict your validator connections to only connect to your full nodes, use secure storage and [key management](https://crypto.org/docs/getting-started/advanced-tmkms-integration.html) service for your validator keys etc.
 :::
 To simplify the following step, we will be using **Linux** for illustration. Binary for
-[Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v1.1.0/chain-main_1.1.0_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v1.1.0/chain-main_1.1.0_Windows_x86_64.zip) are also available. 
+[Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Windows_x86_64.zip) are also available. 
 There are two options to install `chain-maind`: 
 - [Directly from Github](#option-1-install-chain-maind-released-binaries-from-github); or
 - [Homebrew](#option-2-install-chain-maind-by-homebrew)
@@ -38,15 +40,16 @@ There are two options to install `chain-maind`:
 - To install Crypto.org Chain binaries from Github:
 
   ```bash
-  $ curl -LOJ https://github.com/crypto-org-chain/chain-main/releases/download/v1.1.0/chain-main_1.1.0_Linux_x86_64.tar.gz
-  $ tar -zxvf chain-main_1.1.0_Linux_x86_64.tar.gz
+  $ curl -LOJ https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Linux_x86_64.tar.gz
+  $ tar -zxvf chain-main_1.2.1_Linux_x86_64.tar.gz
   ```
 
-- You can verify the installation by checking the version of the chain-maind, the current version is `1.1.0`.
+- You can verify the installation by checking the version of the chain-maind, the current version is `1.2.1`.
   ```bash 
   # check the version of chain-maind
   $ ./chain-maind version
-  1.1.0
+  1.2.1
+  ```
 **OR**
 
 ### Option 2 - Install `chain-maind` by homebrew
@@ -71,7 +74,7 @@ There are two options to install `chain-maind`:
   ```bash 
   # check the version of chain-maind
   $ chain-maind version
-  1.1.0
+  1.2.1
   ```
 ## Step 2. Configure `chain-maind`
 

--- a/docs/getting-started/upgrade_guide.md
+++ b/docs/getting-started/upgrade_guide.md
@@ -1,0 +1,64 @@
+
+# `chain-maind` Binary upgrade guide:
+
+This is a guide for existing validator or full node to upgrade from `v1.1.0`/`v1.2.0` to `v1.2.1`:
+
+
+
+## Step 1 - Get the `v1.2.1` binary
+
+To simplify the following step, we will be using **Linux** for illustration. Binary for
+[Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Windows_x86_64.zip) are also available. 
+
+- Terminate the `chain-maind`; afterwards, download the `v1.2.1` released binaries from github:
+
+  ```bash
+  $ curl -LOJ https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Linux_x86_64.tar.gz
+  $ tar -zxvf chain-main_1.2.1_Linux_x86_64.tar.gz
+  ```
+
+
+    ::: tip Remarks: 
+    If you have stated `chain-maind` with *systemd* service, kindly stop it by 
+
+    ```bash 
+    $ sudo systemctl stop chain-maind
+    ```
+
+    :::
+
+
+
+- For [homebrew](https://github.com/crypto-org-chain/homebrew-chain-maind#chain-maind-homebrew-tap) users, simply run 
+
+    ```bash 
+    $ brew upgrade chain-maind
+    ```
+
+### Step 1.1 -  Verify the version
+
+You can verify the installation by checking the version of `chain-maind`, the current version is `1.2.1`.
+
+  ```bash 
+  # check the version of chain-maind
+  $ ./chain-maind version
+  1.2.1
+  ```
+
+## Step 2. - Run everything
+
+We are ready to start the node and sync the blockchain data:
+
+- Start `chain-maind`, e.g.:
+
+```bash
+  $ ./chain-maind start
+```
+
+Sit back and wait for the syncing process. You can query the node syncing status by
+  ```bash
+  $ ./chain-maind status 2>&1 | jq '.SyncInfo.catching_up'
+  ```
+  If the above command returns `false`, It means that your node **is synced**; otherwise, it returns `true` and implies your node is still catching up.
+
+

--- a/docs/wallets/mainnet-address-generation.md
+++ b/docs/wallets/mainnet-address-generation.md
@@ -47,10 +47,10 @@ Supported OS: Linux, Mac OS and Windows
 
 Download the Crypto.org Chain Binary for Mainnet from [release page](https://github.com/crypto-org-chain/chain-main/releases/tag/v1.0.0) and extract the binary. Here we used Linux as an example:
 
-```bash
-$ curl -LOJ https://github.com/crypto-org-chain/chain-main/releases/download/v1.1.0/chain-main_1.1.0_Linux_x86_64.tar.gz
-$ tar -zxvf chain-main_1.1.0_Linux_x86_64.tar.gz
-```
+ ```bash
+  $ curl -LOJ https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Linux_x86_64.tar.gz
+  $ tar -zxvf chain-main_1.2.1_Linux_x86_64.tar.gz
+  ```
 
 If you are downloading the binary for other operating systems, make sure you are downloading `v1.0.0` or newer version that are targeting for mainnet.
 
@@ -58,7 +58,7 @@ Before moving to the next step, kindly check your `chain-maind` version by
 
 ```bash
 $ ./chain-maind version
-1.1.0
+1.2.1
 ```
 
 #### Step 2. Create a new key and address


### PR DESCRIPTION
Added guide for `v1.2.1` upgrade.