### PR TITLE
[7th June] chain-docs updates

### DIFF
--- a/docs/getting-started/aws-1click.md
+++ b/docs/getting-started/aws-1click.md
@@ -2,7 +2,11 @@
 
 This tutorial will use our AWS 1-click Deployment image to start and create the latest Crypto.org Chain 1-Click Node for both Mainnet and Testnet
 
-
+::: warning CAUTION
+We do not recommend directly running validator on Mainnet by 1-Click deployment. Please use with caution!
+Because the 1-click deployment is not running with [TMKMS](https://github.com/iqlusioninc/tmkms) and your tendermint validator key is in plain text `/chain/.chain-maind/config/priv_validator_key.json`.
+You may consider running validator with [tmkms on AWS nitro-enclave](./advanced-tmkms-integration.html)
+:::
 ## Step 1. AWS Account Creation
 
 You will first need to create an [AWS](https://aws.amazon.com/) account. This will require providing your credit card information to `AWS` and you may be subject to getting charged when you create a virtual machine. More details for account creation, check this [link](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
@@ -215,10 +219,10 @@ If you haven't installed `chain-maind` yet, please follow [Step 1. Get the Crypt
 Mainnet
 ```bash
 $ chain-maind version
-1.2.1
+2.0.1
 ```
 - Mainnet binary for
-  [Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Windows_x86_64.zip) are also available. 
+  [Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v2.0.1/chain-main_2.0.1_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v2.0.1/chain-main_2.0.1_Windows_x86_64.zip) are also available. 
 
 Or
 
@@ -232,11 +236,7 @@ $ chain-maind version
 
 :::
 
-::: warning CAUTION
-We do not recommend directly running validator on Mainnet by 1-Click deployment. Please use with caution!
-Because the 1-click deployment is not running with [TMKMS](https://github.com/iqlusioninc/tmkms) and your tendermint validator key is in plain text `/chain/.chain-maind/config/priv_validator_key.json`.
-You may consider running validator with [tmkms on AWS nitro-enclave](./advanced-tmkms-integration.html)
-:::
+
 
 :::details Mainnet 
 

--- a/docs/getting-started/azure-1click.md
+++ b/docs/getting-started/azure-1click.md
@@ -2,6 +2,11 @@
 
 This tutorial will use our Azure 1-click Deployment image to start and create the latest Croeseid Testnet validator or full node.
 
+::: warning CAUTION
+We do not recommend directly running validator on Mainnet by 1-Click deployment. Please use with caution!
+Because the 1-click deployment is not running with [TMKMS](https://github.com/iqlusioninc/tmkms) and your tendermint validator key is in plain text `/chain/.chain-maind/config/priv_validator_key.json`.
+You may consider running validator with [tmkms on AWS nitro-enclave](./advanced-tmkms-integration.html)
+:::
 ## Step 1. Azure Account Creation
 
 You will first need to create an [Microsoft Azure](https://azure.microsoft.com/) account with a `Pay-As-You-Go` subscription. This will require providing your credit card information to `Microsoft Azure` and you may be subject to getting charged when you create a virtual machine.
@@ -214,10 +219,10 @@ If you haven't installed `chain-maind` yet, please follow [Step 1. Get the Crypt
 Mainnet
 ```bash
 $ chain-maind version
-1.2.1
+2.0.1
 ```
 - Mainnet binary for
-  [Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Windows_x86_64.zip) are also available. 
+  [Mac](https://github.com/crypto-org-chain/chain-main/releases/download/v2.0.1/chain-main_2.0.1_Darwin_x86_64.tar.gz) and [Windows](https://github.com/crypto-org-chain/chain-main/releases/download/v2.0.1/chain-main_2.0.1_Windows_x86_64.zip) are also available. 
 
 Or
 Testnet
@@ -230,11 +235,7 @@ $ chain-maind version
 
 :::
 
-::: warning CAUTION
-We do not recommend directly running validator on Mainnet by 1-Click deployment. Please use with caution!
-Because the 1-click deployment is not running with [TMKMS](https://github.com/iqlusioninc/tmkms) and your tendermint validator key is in plain text `/chain/.chain-maind/config/priv_validator_key.json`.
-You may consider running validator with [tmkms on AWS nitro-enclave](./advanced-tmkms-integration.html)
-:::
+
 
 :::details Mainnet 
 

--- a/docs/getting-started/mainnet.md
+++ b/docs/getting-started/mainnet.md
@@ -305,12 +305,15 @@ confirm transaction before signing and broadcasting [y/N]: y
 
   ::: tip You will be required to insert the following:
   - `--from`: The `cro...` address or the key name that holds your funds for initial delegation;
+  - `--amount`: The amount of self-delegation provided to the validator as an initial staking;
   - `--pubkey`: The validator public key ( See Step [3-2](#step-3-2-obtain-the-validator-public-key) above ) with **crocnclconspub** as the prefix;
   - `--moniker`: A moniker (name) for your validator node;
   - `--security-contact`: Security contact email/contact method, it is **strongly recommended** to provide an email address for receiving important messages related to validator operation in the future;
+  - `--chain-id=`: The chain-id of mainnet - *crypto-org-chain-mainnet-1*
   - `--commission-rate`: The commission rate charge on the delegator;
   - `--commission-max-rate`: The upper bound of the commission rate;
-  - `--commission-max-change-rate`: The maximum daily increase of the validator commission. Please note this parameter cannot be changed after create-validator is processed.
+  - `--commission-max-change-rate`: The maximum daily increase of the validator commission. Please note this parameter cannot be changed after create-validator is processed;
+  - `--min-self-delegation`: The lower threshold of validator's self-delegation amount, if the self-delegation drops below this number, the all staked funds to the validator will be automatically unbonded and the validator will be inactive.
   :::
 
 

--- a/docs/getting-started/mainnet.md
+++ b/docs/getting-started/mainnet.md
@@ -313,7 +313,7 @@ confirm transaction before signing and broadcasting [y/N]: y
   - `--commission-rate`: The commission rate charge on the delegator;
   - `--commission-max-rate`: The upper bound of the commission rate;
   - `--commission-max-change-rate`: The maximum daily increase of the validator commission. Please note this parameter cannot be changed after create-validator is processed;
-  - `--min-self-delegation`: The lower threshold of validator's self-delegation amount, if the self-delegation drops below this number, the all staked funds to the validator will be automatically unbonded and the validator will be inactive.
+  - `--min-self-delegation`: The lower threshold of validator's self-delegation amount, if the self-delegation drops below this number, all staked funds to the validator will be automatically unbonded and the validator will be inactive.
   :::
 
 

--- a/docs/wallets/mainnet-address-generation.md
+++ b/docs/wallets/mainnet-address-generation.md
@@ -48,8 +48,8 @@ Supported OS: Linux, Mac OS and Windows
 Download the Crypto.org Chain Binary for Mainnet from [release page](https://github.com/crypto-org-chain/chain-main/releases/tag/v1.0.0) and extract the binary. Here we used Linux as an example:
 
  ```bash
-  $ curl -LOJ https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Linux_x86_64.tar.gz
-  $ tar -zxvf chain-main_1.2.1_Linux_x86_64.tar.gz
+  $ curl -LOJ https://github.com/crypto-org-chain/chain-main/releases/download/v2.0.1/chain-main_2.0.1_Linux_x86_64.tar.gz
+  $ tar -zxvf chain-main_2.0.1_Linux_x86_64.tar.gz
   ```
 
 If you are downloading the binary for other operating systems, make sure you are downloading `v1.0.0` or newer version that are targeting for mainnet.
@@ -58,7 +58,7 @@ Before moving to the next step, kindly check your `chain-maind` version by
 
 ```bash
 $ ./chain-maind version
-1.2.1
+2.0.1
 ```
 
 #### Step 2. Create a new key and address


### PR DESCRIPTION
1. ` docs/getting-started/aws-1click.md` and `docs/getting-started/azure-1click.md `
  - Placed the warning and recommends at the top of the doc.

2. `docs/getting-started/mainnet.md `
- Added descriptions for required flag where sending the `create-validator` transaction. 

3. Some minor fixes for the binary upgrade 
