### PR TITLE
Removing the repetitive "supply" content

### DIFF
--- a/docs/chain-details/module_overview.md
+++ b/docs/chain-details/module_overview.md
@@ -666,47 +666,7 @@ The following tables show overall effects on different configurations of the sla
 | Constraints          | Value has to be less or equal to `1` | Value has to be less or equal to `1` |
 | Sample configuration | `0.001` (0.1%)                       | `0.05` (5%)                          |
 
-### `supply`
 
-### Introduction
-
-The `supply` module is responsible for retrieve total and liquid supply. 
-
-
-
-### Queries
-
-#### `query supply liquid` - Check the total supply of coins of the chain
-
-We can also use  `query` command of the `supply` module to check the current total supply:
-
-```json
-$ chain-maind query supply total
-    {
-    "supply": [
-        {
-        "denom": "basecro",
-        "amount": "[total_supply_amount]"
-        }
-    ]
-    }
-```
-
-#### `query supply liquid` - Check the liquid supply of coins of the chain
-
-We can also query the liquid supply, which is the total supply bonded subtracted by the non-circulating supply such as bonded amount, unvested amounts, and uncollected reward etc.
-
-```json
-$ chain-maind query supply total
-    {
-    "supply": [
-        {
-        "denom": "basecro",
-        "amount": "[total_circulating_amount]"
-        }
-    ]
-    }
-```
 
 ## `staking`
 


### PR DESCRIPTION
The same content for "supply" already exists at the bottom of the page, while it appears again between "slashing" and "staking".
Removing the repetitive "supply" part.