### PR TITLE
Problem: (Fix #202)Missing instruction on how to get the 'validator-addr' with bech32 prefix

### DIFF
--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -381,6 +381,15 @@ confirm transaction before signing and broadcasting [y/N]: y
 
 ### Step 4-3. `tx staking` - Staking operations
 
+::: tip NOTE
+
+- To get the 'validator-addr' with bech32 prefix, you can run with this command:
+
+  ```bash
+  ./chain-maind keys show Default --bech val
+  ```
+  :::
+
 Staking operations involve the interaction between an address and a validator. It allows you to create a validator and lock/unlocking funds for staking purposes.
 
 #### **Delegate you funds to a validator** [`tx staking delegate <validator-addr> <amount>`]

--- a/docs/getting-started/mainnet_validator.md
+++ b/docs/getting-started/mainnet_validator.md
@@ -358,6 +358,15 @@ confirm transaction before signing and broadcasting [y/N]: y
 
 ### `tx staking` - Staking operations
 
+::: tip NOTE
+
+- To get the 'validator-addr' with bech32 prefix, you can run with this command:
+
+  ```bash
+  ./chain-maind keys show Default --bech val
+  ```
+  :::
+
 Staking operations involve the interaction between an address and a validator. It allows you to create a validator and lock/unlocking funds for staking purposes.
 
 #### **Delegate you funds to a validator** [`tx staking delegate <validator-addr> <amount>`]


### PR DESCRIPTION
Add note to explain how to get the 'validator-addr' with bech32 Prefix.