### PR TITLE
Add instructions on how to make the unsigned macOS binary runnable.

### DIFF
--- a/docs/getting-started/croeseid-testnet.md
+++ b/docs/getting-started/croeseid-testnet.md
@@ -41,6 +41,10 @@ To simplify the following step, we will be using **Linux** (Intel x86) for illus
   ```
 - You can verify the installation by checking the version of the chain-maind, the current version is `3.0.0-croeseid`.
 
+::: tip Reminder:
+For macOS users: the binary is not signed, you have to follow the steps [here](https://support.apple.com/en-hk/guide/mac-help/mh40616/mac) to make the binary runnable.
+:::
+
   ```bash
   $./chain-maind version
   3.0.0-croeseid


### PR DESCRIPTION
Cronos has the same issue 
![image](https://user-images.githubusercontent.com/91446598/135056634-aeb130f2-ee55-4df0-9f50-df06c91f9ba3.png)
